### PR TITLE
feat: mkGigvim { tier, flavor } builder + default flavor

### DIFF
--- a/config/core/theme.nix
+++ b/config/core/theme.nix
@@ -1,19 +1,12 @@
+# Theme-independent visuals shared by every build.
+#
+# The ACTIVE colorscheme (+ style) now lives in the flavor (flavors/*.nix,
+# composed by mkGigvim in flake.nix), so the look travels with the flavor rather
+# than the base config — see gigvim#40. Colorscheme plugins are pulled in by the
+# flavor that selects them.
 {
-  imports = [
-    ../../themes/gruvbox.nix
-    ../../themes/catppuccin.nix
-  ];
-  config.vim = {
-    theme = {
-      enable = true;
-      # name = "gruvbox";
-      # style = "dark";
-      name = "catppuccin";
-      style = "mocha";
-    };
-    visuals = {
-      nvim-web-devicons.enable = true;
-      rainbow-delimiters.enable = true;
-    };
+  config.vim.visuals = {
+    nvim-web-devicons.enable = true;
+    rainbow-delimiters.enable = true;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -63,15 +63,38 @@
         sys:
         let
           pkgs = pkgsFor sys;
-          full = mkNvim sys (import ./full.nix { inherit inputs pkgs; });
-          minimal = mkNvim sys (import ./minimal.nix);
+
+          # Capability TIERS — plugin/LSP depth only. Tiers never touch the look.
+          tiers = {
+            full = import ./full.nix { inherit inputs pkgs; };
+            minimal = import ./minimal.nix;
+          };
+
+          # FLAVORS — the full visual identity (active colorscheme + style, and
+          # as the set grows: dashboard art, statusline accents, purpose plugins).
+          # A flavor is applied at EVERY tier, so a small tier is just as
+          # beautiful as a big one (gigvim#40: tier must not diminish flavor).
+          flavors = {
+            default = import ./flavors/default.nix;
+          };
+
+          # tier x flavor -> a neovim. Beauty (flavor) is orthogonal to size (tier).
+          mkGigvim =
+            {
+              tier ? tiers.full,
+              flavor ? flavors.default,
+            }:
+            mkNvim sys { imports = [ tier flavor ]; };
         in
         {
-          default = full;
-          full = full;
-          gigvim = full;
-          minimal = minimal;
-          mini = minimal;
+          # default / full / gigvim were three identical aliases — now one build,
+          # full tier + the default flavor.
+          default = mkGigvim { };
+          full = mkGigvim { };
+          gigvim = mkGigvim { };
+          # minimal tier, SAME default flavor — proof that tier ⊥ flavor.
+          minimal = mkGigvim { tier = tiers.minimal; };
+          mini = mkGigvim { tier = tiers.minimal; };
         }
       );
 

--- a/flavors/default.nix
+++ b/flavors/default.nix
@@ -1,0 +1,17 @@
+# The `default` gigvim flavor — the reference visual identity.
+#
+# A flavor carries the whole look: the active colorscheme (+ style) and, as the
+# flavor set grows, its dashboard art, statusline accents, and purpose plugins.
+# Flavors are applied at EVERY tier (gigvim#40: tier scales capability, never
+# beauty), so `minimal` + `default` is exactly as pretty as `full` + `default`.
+{ ... }:
+{
+  imports = [
+    ../themes/catppuccin.nix # the colorscheme plugin
+  ];
+  config.vim.theme = {
+    enable = true;
+    name = "catppuccin";
+    style = "mocha";
+  };
+}


### PR DESCRIPTION
First slice of gigvim#40 — establishes the **tier × flavor** model, starting with the `default` flavor as the reference.

## The model
- **tier** = capability depth (`full`, `minimal`) — plugin/LSP weight only.
- **flavor** = the whole visual identity (active colorscheme + style now; dashboard art / statusline accents / purpose plugins as the set grows).
- **flavor is applied at every tier**, so `minimal` + `default` is exactly as beautiful as `full` + `default` — your "tier should not diminish flavor."

## Changes
- **`flavors/default.nix`** (new) — the reference flavor: `catppuccin mocha` + its plugin.
- **`config/core/theme.nix`** — stripped the active colorscheme selection (moved into the flavor); keeps only theme-independent visuals (devicons, rainbow-delimiters).
- **`flake.nix`** — `tiers { full, minimal }`, `flavors { default }`, and `mkGigvim { tier ? full, flavor ? default }`. Every package output now routes through it. The previously-**redundant** `default`/`full`/`gigvim` (three identical aliases) are now one build; `minimal`/`mini` keep the **same** default flavor at the smaller tier.

## Next (this PR is the foundation)
Fan out flavors as pure data on the same builder — `nix` (ships gigvim#39's tooling), `rust`, `writing` — each just `{ scheme, art, accent, purpose }`.

## ⚠️ Verification
No `nix` in the authoring env and gigvim has no CI, so this is **not built here**. Please `nix build .#default` and `.#minimal` to confirm the `imports = [ tier flavor ]` composition evaluates under nvf (esp. that moving `vim.theme` into the flavor merges correctly). It's a small, mechanical composition, but nvf module-merge should be eyeballed on a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzL4cScskx8GfajDA1VZuj)_